### PR TITLE
hide_cli_on_diversion feature implemented

### DIFF
--- a/src/Xuma/Bfxm/Builder.php
+++ b/src/Xuma/Bfxm/Builder.php
@@ -112,12 +112,13 @@ class Builder
      * @param $num
      * @return $this
      */
-    public function dial($num)
+    public function dial($num,$display_caller=false)
     {
         $this->add(array(
             "action"=>"dial",
             "args"=>array(
-                "destination"=>$num
+                "destination"=>$num,
+                "hide_cli_on_diversion"=>$display_caller
             )
         ));
 


### PR DESCRIPTION
Caller ID is hidden for callee as a default behaviour on BFXM. 

**hide_cli_on_diversion** parameter added to BFON standard to change this behaviour and supported on Bulutfon XM service. An extra parameter added to dial method.

**Example Usage:**
`$bfxm->dial("905321234567", true);`
